### PR TITLE
shadow IPMask type

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -144,8 +144,8 @@ func (i4 I4) IP() net.IP {
 }
 
 // Mask returns the Mask
-func (i4 I4) Mask() net.IPMask {
-	return net.CIDRMask(i4.maskBits, 32)
+func (i4 I4) Mask() IPMask {
+	return IPMask(net.CIDRMask(i4.maskBits, 32))
 }
 
 // MaskBits returns the Mask

--- a/ip_test.go
+++ b/ip_test.go
@@ -144,7 +144,7 @@ func TestI4_Mask(t *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   net.IPMask
+		want   IPMask
 	}{
 		{
 			name: "10.0.0.1/24",
@@ -152,7 +152,7 @@ func TestI4_Mask(t *testing.T) {
 				ip:       167772161,
 				maskBits: 24,
 			},
-			want: net.CIDRMask(24, 32),
+			want: CIDRMask(24, 32),
 		},
 	}
 	for _, tt := range tests {

--- a/mask.go
+++ b/mask.go
@@ -10,3 +10,34 @@ func InvertIPMask(in net.IPMask) net.IPMask {
 	}
 	return out
 }
+
+// IPMask is like the net.IPMask type
+type IPMask []byte
+
+// CIDRMask points to net.CIDRMask
+func CIDRMask(ones, bits int) IPMask {
+	return IPMask(net.CIDRMask(ones, bits))
+}
+
+// IPv4Mask points to net.IPv4Mask
+func IPv4Mask(a, b, c, d byte) IPMask {
+	return IPMask(net.IPv4Mask(a, b, c, d))
+}
+
+// Size points to net.IPMask.Size
+func (m IPMask) Size() (ones, bits int) {
+	return net.IPMask(m).Size()
+}
+
+// String points to net.IPMask.String
+func (m IPMask) String() string {
+	return net.IPMask(m).String()
+}
+
+// Invert inverts the Mask and returns itself
+func (m IPMask) Invert() IPMask {
+	for i := range m {
+		m[i] = ^m[i]
+	}
+	return m
+}

--- a/mask_test.go
+++ b/mask_test.go
@@ -31,3 +31,29 @@ func TestInvertIPMask(t *testing.T) {
 		})
 	}
 }
+
+func TestIPMask_Invert(t *testing.T) {
+	tests := []struct {
+		name string
+		m    IPMask
+		want IPMask
+	}{
+		{
+			name: "t1",
+			m:    CIDRMask(16, 32),
+			want: IPv4Mask(0, 0, 255, 255),
+		},
+		{
+			name: "t2",
+			m:    CIDRMask(17, 32),
+			want: IPv4Mask(0, 0, 127, 255),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.m.Invert(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IPMask.Invert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- changing I4.Mask to local type instead of net.IPMask
- creating IPMask type that has the same interface as net.IPMask
- adding an Invert() method
- some test coverage